### PR TITLE
feat: implement loadBlockchainData and on accountsChanged.

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -23,9 +23,31 @@ function App() {
   const [toggle, setToggle] = useState(false);
 
   const loadBlockchainData = async () => {
-    // TODO: 
-    // - load blockchain data
-    // - set accountsChanged to handle account changes from the wallet
+    const provider = new ethers.providers.Web3Provider(window.ethereum)
+    setProvider(provider)
+    const network = await provider.getNetwork()
+
+    const realEstate = new ethers.Contract(config[network.chainId].realEstate.address, RealEstate, provider)
+    const totalSupply = await realEstate.totalSupply()
+    const homes = []
+
+    for (var i = 1; i <= totalSupply; i++) {
+      const uri = await realEstate.tokenURI(i)
+      const response = await fetch(uri)
+      const metadata = await response.json()
+      homes.push(metadata)
+    }
+
+    setHomes(homes)
+
+    const escrow = new ethers.Contract(config[network.chainId].escrow.address, Escrow, provider)
+    setEscrow(escrow)
+
+    window.ethereum.on('accountsChanged', async () => {
+      const accounts = await window.ethereum.request({ method: 'eth_requestAccounts' });
+      const account = ethers.utils.getAddress(accounts[0])
+      setAccount(account);
+    })
   }
 
   useEffect(() => {


### PR DESCRIPTION
### Issue
Due to an application's failure to load expected blockchain data on initialization, the homes array is empty, which in turn stops property listings from being displayed. Also, the Navigation component connection button does not change when different accounts in the wallet are selected, which means that the account which is being displayed does not correspond to the wallet that is connected.  

### Solution
Use the loadBlockchainData function to retrieve estate contract data and fill the state variables. Also, add an accountsChanged event listener which automatically updates the current account for the user when accounts are switched in the wallet. The function should initialize Web3 provider, retrieve property metadata from RealEstate contract, and set appropriate accounts synchronization.  

### Requirements
The loadBlockchainData function should create Web3 provider, instantiate the RealEstate contract, fetch total supply, iterate through tokens to retrieve metadata URIs, fill the homes state array, and initialize the Escrow contract. Also, there is an accountsChanged event that when registered updates the account state when wallet accounts change. Make sure to use ethers.utils.getAddress() to format an address properly.

